### PR TITLE
Fix jQuery loading issue in lab website

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -59,7 +59,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.js" integrity="sha384-/y1Nn9+QQAipbNQWU65krzJralCnuOasHncUFXGkdwntGeSvQicrYkiUBwsgUqc1" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/contrib/auto-render.min.js" integrity="sha384-dq1/gEHSxPZQ7DdrM82ID4YVol9BYyU7GbWlIwnwyPzotpoc57wDw/guX8EaYGPx" crossorigin="anonymous"></script>
-<script src="https://code.jquery.com/jquery-1.12.4.min.js" integrity="sha256-ZosEbRLbNQzLpnKIkEdrPv7lOy9C27hHQ+Xp8a4MxAQ=" crossorigin="anonymous"></script>
+<script src="{{ "js/jquery.min.js" | absURL }}"></script>
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
 <script src="{{ "js/main.js" | absURL }}"></script>
 {{- if .Site.Params.staticman }}


### PR DESCRIPTION
The site was loading an outdated jQuery 1.12.4 from CDN while the theme had been updated to jQuery 3.7.1. This caused conflicts and potential security issues. Updated footer.html to load the local jQuery 3.7.1 file instead of the old CDN version.

Changes:
- Updated layouts/partials/footer.html to use local jQuery file
- Removed CDN reference to jQuery 1.12.4
- Now uses the updated jQuery 3.7.1 from theme's static directory