### PR TITLE
Fix Hugo 0.101.0 compatibility issues in head.html

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,11 +17,9 @@
           {{ end }}
           {{ if .Site.Params.rss }}
           <li>
-            {{ if .RSSLink }}
-            <a href="{{ .RSSLink }}" title="RSS">
-            {{ else }}
-            <a href="{{ .Site.RSSLink }}" title="RSS">
-            {{ end }}
+            {{- with .OutputFormats.Get "RSS" }}
+            <a href="{{ .Permalink }}" title="RSS">
+            {{- end }}
               <span class="fa-stack fa-lg">
                 <i class="fa fa-circle fa-stack-2x"></i>
                 <i class="fa fa-rss fa-stack-1x fa-inverse"></i>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,7 +34,7 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ .Site.Title }}" />
 <!-- Hugo Version number -->
-  {{ .Hugo.Generator -}}
+  {{ hugo.Generator -}}
 <!-- Links and stylesheets -->
   <link rel="canonical" href="{{ .Permalink }}" />
   {{- with .OutputFormats.Get "RSS" }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,17 +30,15 @@
 {{- with .Site.Params.fb_app_id }}
   <meta property="fb:app_id" content="{{ . }}" />
 {{- end }}
-  <meta property="og:url" content="{{ .URL | absLangURL }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="{{ .Site.Title }}" />
 <!-- Hugo Version number -->
   {{ .Hugo.Generator -}}
 <!-- Links and stylesheets -->
-  <link rel="canonical" href="{{ .URL | absLangURL }}" />
-  {{- if .RSSLink }}
-  <link rel="alternate" href="{{ .RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
-  {{- else }}
-  <link rel="alternate" href="{{ .Site.RSSLink }}" type="application/rss+xml" title="{{ .Site.Title }}">
+  <link rel="canonical" href="{{ .Permalink }}" />
+  {{- with .OutputFormats.Get "RSS" }}
+  <link rel="alternate" href="{{ .Permalink }}" type="application/rss+xml" title="{{ $.Site.Title }}">
   {{- end }}
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/KaTeX/0.7.1/katex.min.css" integrity="sha384-wITovz90syo1dJWVh32uuETPVEtGigN07tkttEqPv+uR2SE/mbQcG7ATL28aI9H0" crossorigin="anonymous">
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">

--- a/layouts/partials/post_meta.html
+++ b/layouts/partials/post_meta.html
@@ -11,7 +11,7 @@
   {{ end }}
   {{- if .Site.Params.staticman -}}
     &nbsp;|&nbsp;  <i class="fa fa-comment-o"></i>
-    {{ $slug := replace .URL "/" "" }}
+    {{ $slug := replace .RelPermalink "/" "" }}
     {{ if .Site.Data.comments }}
       {{ $comments := index $.Site.Data.comments $slug }}
       {{ if $comments }}

--- a/layouts/partials/staticman-comments.html
+++ b/layouts/partials/staticman-comments.html
@@ -36,7 +36,7 @@
 
 
 <form class="js-form form" method="post" action="{{ .Site.Params.staticman.api}}">
-  <input type="hidden" name="options[slug]" value="{{ replace .URL "/" "" }}">
+  <input type="hidden" name="options[slug]" value="{{ replace .RelPermalink "/" "" }}">
   <input type="hidden" name="options[parent]" value="">
 
   {{ if .Site.Params.staticman.recaptcha }}


### PR DESCRIPTION
Replaced deprecated Hugo template variables with current equivalents:
- Changed .URL to .Permalink (lines 33 and 39)
- Changed .RSSLink/.Site.RSSLink to .OutputFormats.Get "RSS"

These fields were deprecated in Hugo 0.101.0 and caused build failures: "can't evaluate field URL in type *hugolib.pageState"

The .Permalink provides the same functionality and is the recommended replacement for .URL in Hugo 0.101.0+.