### PR TITLE
Fix .URL deprecation in list.html and .Hugo.Version in i18n

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -1,0 +1,3 @@
+# Footer
+- id: poweredBy # Accepts HTML
+  translation: '<a href="http://gohugo.io">Hugo v{{ hugo.Version }}</a> powered &nbsp;&bull;&nbsp; Theme by <a href="http://deanattali.com/beautiful-jekyll/">Beautiful Jekyll</a> adapted to <a href="https://github.com/halogenica/beautifulhugo">Beautiful Hugo</a>'

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -68,12 +68,12 @@
           <ul class="pager main-pager">
             {{ if .Paginator.HasPrev }}
               <li class="previous">
-                <a href="{{ .URL }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
+                <a href="{{ .RelPermalink }}page/{{ .Paginator.Prev.PageNumber }}/">&larr; {{ i18n "newerPosts" }}</a>
               </li>
             {{ end }}
             {{ if .Paginator.HasNext }}
               <li class="next">
-                <a href="{{ .URL }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
+                <a href="{{ .RelPermalink }}page/{{ .Paginator.Next.PageNumber }}/">{{ i18n "olderPosts" }} &rarr;</a>
               </li>
             {{ end }}
           </ul>


### PR DESCRIPTION
Fixed final Hugo 0.101.0 compatibility issues:

1. layouts/_default/list.html (lines 71, 76):
   - Changed .URL to .RelPermalink for pagination links

2. Created i18n/en.yaml override:
   - Fixed "poweredBy" translation to use hugo.Version instead of .Hugo.Version
   - This eliminates the warnings about deprecated .Hugo.Version field

These were the last remaining deprecated template variables causing build failures and warnings.